### PR TITLE
add serde support as a feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,7 @@ readme = "README.md"
 keywords = ["slice", "tagged", "pointer"]
 
 [dependencies]
+serde = { version = "1.0.130", optional = true }
+
+[dev-dependencies]
+bincode = "1.3.3"


### PR DESCRIPTION
Added _serde_ as a feature to be able to serialize/deserialize the ThinBoxedSlice. Ideally, in the future this would be zero-copy but this can be a first iteration as zero-copy would require wider changes.